### PR TITLE
Fix crash when the game ends with a mate or a stalemate

### DIFF
--- a/ostap/ostap.py
+++ b/ostap/ostap.py
@@ -89,10 +89,17 @@ def evaluation(engine, board, analysis_options = ANALYSIS_OPTIONS):
 		multipv = analysis_options[ANALYSIS_OPTION_MULTIPV],
 		info = chess.engine.INFO_ALL)
 
+	# extract the notation for the move suggested by the engine in this info.
+	# final positions like mate, stalemate do not have move suggestions.
+	def move_suggested(info, board):
+		if 'pv' in info:
+			return Move(board.san(info['pv'][0]), info['pv'][0].uci())
+		return Move(None, None)
+
 	return Position(fen = board.fen(),
 		evaluations = [
 			Evaluation(info['score'].white().score(mate_score=1000)/100.0,
-			Move(board.san(info['pv'][0]), info['pv'][0].uci())) for info in infos])
+			move_suggested(info, board)) for info in infos])
 
 
 def errors(positions, threshold = ANALYSIS_THRESHOLD_ERROR):

--- a/ostap/templates/game.html
+++ b/ostap/templates/game.html
@@ -25,7 +25,9 @@
 {% macro move_played(fen, move) -%}
   {% set fen_fields = fen.split() %}
   {% set badge = badges[fen][0] %}
+  {% if move %}
   <span class="played-move badge-{{badge}}" title="{{badge_tooltips[badge]}}">{{fen_fields[5]}}{% if fen_fields[1] == 'b' %}...{% else %}&nbsp;{% endif %}{{move}}</span>&nbsp;|&nbsp;
+  {% endif %}
 {%- endmacro %}
 
 <div class="diagrams">


### PR DESCRIPTION
If the final position is a mate or a stalemate the engine cannot recommend moves and this leads to missing keys in the info dictionary.

Fixes #4